### PR TITLE
Remove redundant download buttons

### DIFF
--- a/app.R
+++ b/app.R
@@ -85,16 +85,8 @@ ui <- fluidPage(
       ),
       
       hr(),
-      actionButton("run_analysis", "Run Analysis"),
+      actionButton("run_analysis", "Run Analysis")
       
-      # Download Buttons for Analysis Plots and Summaries
-      hr(),
-      h4("Download Analysis Outputs"),
-      downloadButton("download_forest_uni", "Download Univariate Forest Plot"),
-      downloadButton("download_forest_multi", "Download Multivariate Forest Plot"),
-      downloadButton("download_km_plot", "Download Kaplan-Meier Plot"),
-      downloadButton("download_schoenfeld_uni", "Download Univariate Schoenfeld Plot"),
-      downloadButton("download_schoenfeld_multi", "Download Multivariate Schoenfeld Plot")
     ),
     
     mainPanel(


### PR DESCRIPTION
## Summary
- trim the sidebar UI so there is only one set of download buttons, located in each tab

## Testing
- *No automated tests exist for this repo*


------
https://chatgpt.com/codex/tasks/task_e_68444139e5a8832a9bcec2a1485daee1